### PR TITLE
Support get uids and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,14 @@ func (api *API) GetUsage(conf UsageConfig) (*Usage, error) {}
 // DeleteUsage removes usage information. With no dates specified, removes all usage information
 func (api *API) DeleteUsage(conf UsageConfig) error {}
 
+// GetUIDs gets all UIDs.
+func (api *API) GetUIDs() ([]string, error) {}
+
 // GetUser gets user information. If no user is specified returns the list of all users along with suspension information
 func (api *API) GetUser(uid ...string) (*User, error) {}
+
+// GetUsers get all user information.
+func (api *API) GetUsers() ([]*User, error) {}
 
 // CreateUser creates a new user. By Default, a S3 key pair will be created automatically and returned in the response.
 func (api *API) CreateUser(conf UserConfig) (*User, error) {}

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -103,6 +103,46 @@ func (api *API) GetUser(uid ...string) (*User, error) {
 	return ret, nil
 }
 
+// GetUIDs gets all UIDs.
+//
+// !! caps: users=read !!
+//
+func (api *API) GetUIDs() ([]string, error) {
+	var ret []string
+	values := url.Values{}
+
+	values.Add("format", "json")
+	body, _, err := api.call("GET", "/metadata/user", values, true)
+	if err != nil {
+		return ret, err
+	}
+	if err = json.Unmarshal(body, &ret); err != nil {
+		return ret, err
+	}
+	return ret, nil
+}
+
+// GetUsers get all user information.
+//
+// !! caps: users=read !!
+//
+func (api *API) GetUsers() ([]*User, error) {
+	var ret []*User
+
+	uids, err := api.GetUIDs()
+	if err != nil {
+		return ret, err
+	}
+	ret = make([]*User, len(uids))
+	for idx, uid := range uids {
+		ret[idx], err = api.GetUser(uid)
+		if err != nil {
+			return ret, err
+		}
+	}
+	return ret, nil
+}
+
 // UserConfig user request
 type UserConfig struct {
 	UID         string `url:"uid,ifStringIsNotEmpty"`          // The user ID to be created

--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -89,6 +89,26 @@ func TestUser(t *testing.T) {
 		So(user, ShouldNotBeNil)
 	})
 
+	Convey("Testing Get UIDs", t, func() {
+		api := createNewAPI()
+
+		uids, err := api.GetUIDs()
+		So(err, ShouldBeNil)
+		So(uids, ShouldContain, "UnitTest")
+	})
+
+	Convey("Testing Get users", t, func() {
+		api := createNewAPI()
+
+		user, err := api.GetUser("UnitTest")
+		So(err, ShouldBeNil)
+		So(user, ShouldNotBeNil)
+
+		users, err := api.GetUsers()
+		So(err, ShouldBeNil)
+		So(users, ShouldContain, user)
+	})
+
 	Convey("Testing Update user", t, func() {
 		api := createNewAPI()
 


### PR DESCRIPTION
The implementation of `GetUIDs` is inspired by `radosgw-admin`, and new APIs have been tested with go1.7.6 and ceph mimic.

Reference:
- https://github.com/valerytschopp/python-radosgw-admin/blob/master/radosgw/connection.py#L160
- http://docs.ceph.com/docs/mimic/radosgw/adminops

BTW, it looks like goconvey is broken with the latest version of Go: https://github.com/smartystreets/goconvey/issues/476.

