### PR TITLE
Fix unsuspending user

### DIFF
--- a/pkg/api/encodeUrl.go
+++ b/pkg/api/encodeUrl.go
@@ -10,6 +10,7 @@ import (
 
 func init() {
 	encurl.AddEncodeFunc(ifTimeIsNotNilCeph)
+	encurl.AddEncodeFunc(boolIfNotNil)
 }
 
 func ifTimeIsNotNilCeph(obj interface{}) (string, bool, error) {
@@ -22,4 +23,17 @@ func ifTimeIsNotNilCeph(obj interface{}) (string, bool, error) {
 		return "", false, nil
 	}
 	return "", false, errors.New("this field should be a *time.Time")
+}
+
+func boolIfNotNil(obj interface{}) (string, bool, error) {
+	if val, ok := obj.(*bool); ok {
+		if val != nil {
+			if *val {
+				return "True", true, nil
+			}
+			return "False", true, nil
+		}
+		return "", false, nil
+	}
+	return "", false, errors.New("this field should be a *boolean")
 }

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -154,7 +154,7 @@ type UserConfig struct {
 	UserCaps    string `url:"user-caps,ifStringIsNotEmpty"`    // User capabilities
 	MaxBuckets  *int   `url:"max-buckets,itoaIfNotNil"`        // Specify the maximum number of buckets the user can own
 	GenerateKey bool   `url:"generate-key,ifBoolIsTrue"`       // Generate a new key pair and add to the existing keyring
-	Suspended   bool   `url:"suspended,ifBoolIsTrue"`          // Specify whether the user should be suspended
+	Suspended   *bool  `url:"suspended,boolIfNotNil"`          // Specify whether the user should be suspended
 	PurgeData   bool   `url:"purge-data,ifBoolIsTrue"`         // When specified the buckets and objects belonging to the user will also be removed
 }
 


### PR DESCRIPTION
This changes `Suspend` user flag to `*bool` to allow for unsuspending user without the need to always pass the desired state - when pointer is nil nothing is passed and existing value is retained. Before when `false` was passed, it was ignored.